### PR TITLE
使索引取值支持 path 格式

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -21,7 +21,7 @@ class Engine {
                 keywords = Engine.participle(item, dict, prefix);
             } else {
                 for (const key of indexs) {
-                    const words = item[key];
+                    const words = resolve(key, item);
                     if (words) {
                         keywords += Engine.participle(words, dict, prefix);
                     }
@@ -109,5 +109,10 @@ class Engine {
         return result;
     }
 };
+
+function resolve(path, obj, separator='.') {
+    let properties = Array.isArray(path) ? path : path.split(separator)
+    return properties.reduce((prev, curr) => prev && prev[curr], obj)
+}
 
 module.exports = Engine;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,8 @@ describe('PinyinEngine()', () => {
             assert.deepEqual(['中央美院'], pinyinEngine.query('meiyuan'));
         });
         it('数据应当支持 `[Object]`', () => {
-            const pinyinEngine = new PinyinEngine([{
+            const pinyinEngine = new PinyinEngine([
+                {
                     id: 0,
                     name: '清华大学'
                 },
@@ -30,6 +31,33 @@ describe('PinyinEngine()', () => {
             assert.deepEqual([{
                 id: 3,
                 name: '中央美院'
+            }], pinyinEngine.query('meiyuan'));
+        });
+        it('索引取值应当支持 path 格式', () => {
+            const pinyinEngine = new PinyinEngine([{
+                    id: 0,
+                    deep: {
+                        name: '清华大学'
+                    }
+                },
+                {
+                    id: 1,
+                    deep: {
+                        name: '北京大学'
+                    }
+                },
+                {
+                    id: 3,
+                    deep: {
+                        name: '中央美院'
+                    }
+                }
+            ], ['deep.name']);
+            assert.deepEqual([{
+                id: 3,
+                deep: {
+                    name: '中央美院'
+                }
             }], pinyinEngine.query('meiyuan'));
         });
         it('应当支持拼音首字母', () => {


### PR DESCRIPTION
由于有时候需要获取 `Object` 内的 nested value，故添加索引取值的 path 格式支持。

例：修改后，即可使用 `deep.name` 对 `{deep: {name: "foobar"}}` 中的 `"foobar"` 进行引用

:D